### PR TITLE
Install bids validator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,10 @@ RUN apt-get update && apt-get -y install \
     jq \
     tar \
     zip \
-    build-essential
+    build-essential \
+    nodejs
 
+RUN npm install -g bids-validator
 
 ############################
 # Install the Flywheel SDK

--- a/create_archive.py
+++ b/create_archive.py
@@ -125,12 +125,13 @@ if __name__ == '__main__':
         container = fw.get_project(container_id)
     elif container_type == 'session':
         # If container type is a session, get the specific session
-        container = fw.get_session(container_id)
+        session = fw.get_session(container_id)
+        container = fw.get_project(session.project)
 
     BIDS_metadata = container.get('info', {}).get('BIDS')
     if BIDS_metadata:
         try:
-            export_bids.export_bids(fw, rootdir, None, container_type=container_type, container_id=container_id, validate=False)
+            export_bids.export_bids(fw, rootdir, container.label, subjects=[session.subject.code], sessions=[session.label], validate=False)
             if BIDS_metadata != 'NA':
                 if container_type == 'session':
                     download_optional_inputs(flywheel_basedir, "sub-{}".format(BIDS_metadata.get('Subject')), "ses-{}".format(BIDS_metadata.get('Label')))

--- a/create_archive.py
+++ b/create_archive.py
@@ -130,7 +130,7 @@ if __name__ == '__main__':
     BIDS_metadata = container.get('info', {}).get('BIDS')
     if BIDS_metadata:
         try:
-            export_bids.export_bids(fw, rootdir, None, container_type=container_type, container_id=container_id)
+            export_bids.export_bids(fw, rootdir, None, container_type=container_type, container_id=container_id, validate=False)
             if BIDS_metadata != 'NA':
                 if container_type == 'session':
                     download_optional_inputs(flywheel_basedir, "sub-{}".format(BIDS_metadata.get('Subject')), "ses-{}".format(BIDS_metadata.get('Label')))

--- a/manifest.json
+++ b/manifest.json
@@ -45,7 +45,7 @@
     "ignore_bids_validation": {
       "description": "Ignore bids validation and continue with fmriprep if validation fails",
       "type": "boolean",
-      "default": true
+      "default": false
     },
     "fs_no_reconall": {
       "description": "Use FreeSurfer to reconstruct surfaces from T1w/T2w structural images. If disabled, several steps in the fmriprep pipeline are added or replaced. [default=false]",

--- a/manifest.json
+++ b/manifest.json
@@ -45,7 +45,7 @@
     "ignore_bids_validation": {
       "description": "Ignore bids validation and continue with fmriprep if validation fails",
       "type": "boolean",
-      "default": false
+      "default": true
     },
     "fs_no_reconall": {
       "description": "Use FreeSurfer to reconstruct surfaces from T1w/T2w structural images. If disabled, several steps in the fmriprep pipeline are added or replaced. [default=false]",

--- a/manifest.json
+++ b/manifest.json
@@ -42,6 +42,11 @@
     }
   },
   "config": {
+    "ignore_bids_validation": {
+      "description": "Ignore bids validation and continue with fmriprep if validation fails",
+      "type": "boolean",
+      "default": false
+    },
     "fs_no_reconall": {
       "description": "Use FreeSurfer to reconstruct surfaces from T1w/T2w structural images. If disabled, several steps in the fmriprep pipeline are added or replaced. [default=false]",
       "type": "boolean",

--- a/run
+++ b/run
@@ -232,12 +232,13 @@ fi
 
 ################################################################################
 # VALIDATE INPUT DATA
-# Check if the input directory is not empty
-if [[ "$(ls -A $INPUT_DIR)" ]] ; then
-    echo "$CONTAINER  Starting..."
+# Check if it is correct bids format
+bids-validator "$BIDS_DIR"
+if [[ $? != 0 ]]; then
+  echo "$CONTAINER  Not a valid BIDS Dataset! Exiting (1)"
+  exit 1
 else
-    echo "Input directory is empty: $INPUT_DIR"
-    exit 1
+    echo "$CONTAINER  Starting..."
 fi
 
 # Show the contents of the BIDS directory

--- a/run
+++ b/run
@@ -60,6 +60,7 @@ config_intermediate_folders="$(parse_config 'intermediate_folders')"
 ##################
 # Workflow Options
 config_ignore="$(parse_config 'ignore')"
+config_ignore_bids_validation="$(parse_config 'ignore_bids_validation')"
 config_longitudinal="$(parse_config 'longitudinal')"
 config_t2s_coreg="$(parse_config 't2s_coreg')"
 config_bold2t1w_dof="$(parse_config 'bold2t1w_dof')"
@@ -235,8 +236,10 @@ fi
 # Check if it is correct bids format
 bids-validator "$BIDS_DIR"
 if [[ $? != 0 ]]; then
-  echo "$CONTAINER  Not a valid BIDS Dataset! Exiting (1)"
-  exit 1
+  echo "$CONTAINER  Not a valid BIDS Dataset!"
+  if [[ $config_ignore_bids_validation == 'false' ]]; then
+    echo "Exiting (1)"
+    exit 1
 else
     echo "$CONTAINER  Starting..."
 fi

--- a/run
+++ b/run
@@ -240,6 +240,7 @@ if [[ $? != 0 ]]; then
   if [[ $config_ignore_bids_validation == 'false' ]]; then
     echo "Exiting (1)"
     exit 1
+  fi
 else
     echo "$CONTAINER  Starting..."
 fi


### PR DESCRIPTION
BIDS export tries to validate the downloaded bids hierarchy but skips it when it can't find it. This would prevent a lot of 24 hour fmriprep runs that are going to fail.
Should we give a config option to skip bids validation?

Example of logs currently:
`WARNING:utils:Skipping validation, validator is not present `