### PR TITLE
fmriprep bids validation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,10 +41,8 @@ RUN chmod +x ${FLYWHEEL}/*
 
 ############################
 # Install the Flywheel SDK and BIDS client
-RUN pip install --upgrade pip \
-                          cython \
-                          flywheel-sdk \
-                          flywheel_bids
+RUN pip install flywheel-sdk \
+                flywheel_bids
 
 
 ############################

--- a/create_archive.py
+++ b/create_archive.py
@@ -122,20 +122,21 @@ if __name__ == '__main__':
     # Determine if ID is a project or a session ID
     if container_type == 'project':
         # Get list of sessions within project
-        container = fw.get_project(container_id)
+        project = fw.get_project(container_id)
     elif container_type == 'session':
         # If container type is a session, get the specific session
-        container = fw.get_session(container_id)
+        session = fw.get_session(container_id)
+        project = fw.get_project(session.project)
 
-    BIDS_metadata = container.get('info', {}).get('BIDS')
+    BIDS_metadata = project.get('info', {}).get('BIDS')
     if BIDS_metadata:
         try:
-            export_bids.export_bids(fw, rootdir, None, container_type=container_type, container_id=container_id)
+            export_bids.export_bids(fw, rootdir, project.label, subjects=[session.subject.code], sessions=[session.label], validate=False)
             if BIDS_metadata != 'NA':
                 if container_type == 'session':
                     download_optional_inputs(flywheel_basedir, "sub-{}".format(BIDS_metadata.get('Subject')), "ses-{}".format(BIDS_metadata.get('Label')))
             else:
-                print('BIDS Curation was not valid, cannot use additional files.')
+                print('BIDS Curation was not valid, will not download additional files.')
 
         except SystemExit:  # This is a necessary evil until bids_export doesn't call sys.exit(1)
             print('Curated BIDS export failed, using on-the-fly bids-export')

--- a/manifest.json
+++ b/manifest.json
@@ -7,9 +7,9 @@
   "maintainer": "Flywheel <support@flywheel.io>",
   "source": "https://github.com/flywheel-apps/fmriprep",
   "url": "https://fmriprep.readthedocs.io/en/1.2.6-1/",
-  "version": "5.6.2_1.2.6-1",
+  "version": "5.7.0_1.2.6-1",
   "custom": {
-    "docker-image": "flywheel/fmriprep:5.6.2_1.2.6-1"
+    "docker-image": "flywheel/fmriprep:5.7.0_1.2.6-1"
   },
   "license": "Other",
   "inputs": {

--- a/run
+++ b/run
@@ -60,7 +60,7 @@ config_intermediate_folders="$(parse_config 'intermediate_folders')"
 # BIDS Options
 config_skip_bids_validation="$(parse_config 'skip_bids_validation')"
 if [[ $config_skip_bids_validation == 'false' ]]; then
-  _FLAG=''
+  skip_bids_validation_FLAG=''
 else
   skip_bids_validation_FLAG='--skip-bids-validation'
 fi
@@ -82,7 +82,7 @@ fi
 ##################
 # Performance Options
 config_anat_only="$(parse_config 'anat_only')"
-if [[ $config_ == 'false' ]]; then
+if [[ $config_anat_only == 'false' ]]; then
   anat_only_FLAG=''
 else
   anat_only_FLAG='--anat-only'
@@ -308,7 +308,8 @@ ls -R ${BIDS_DIR}
 
 ################################################################################
 # RUN FMRIPREP
-echo -e "time /usr/local/miniconda/bin/fmriprep \
+echo -e "RUNNING COMMAND: \n
+      /usr/local/miniconda/bin/fmriprep \
       ${BIDS_DIR} \
       ${FMRIPREP_OUTPUT_DIR} \
       participant \
@@ -386,7 +387,7 @@ if [[ $FMRIPREP_EXITSTATUS == 0 ]] ; then
   # Convert html to standalone zip archive
   html_file=$(find "$FMRIPREP_OUTPUT_DIR"/fmriprep/ -name "sub-*.html")
   SUB_ID=$(basename "$html_file" .html)
-  
+
   if [[ -n "$html_file" ]]; then
     echo "$CONTAINER  Converting output html report..."
     output_html_file="$GEAR_OUTPUT_DIR"/`basename "$html_file" .html`_"$ANALYSIS_ID".html.zip


### PR DESCRIPTION
Set `export_bids` bids validation to `false` and thus allow fmriprep to handle bids validation (which is a new functionality in this version) - depending on the option set on the manifest config.